### PR TITLE
Removed the single marker object support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,22 +33,7 @@ mapOptions : {
     //I promise a callback is assured for the particular event so
     //have your code here
   },
-  //If you have single marker then can use this,
-  //prefer to use markers option even for single marker
-  marker : {
-    latitude : 'Your marker latitude if empty will takes up the center latitude',
-    longitude : 'Your marker longitude if empty will takes up the center longitude',
-    title : 'Your title, if not provided it takes up as empty string',
-    animation : 'DROP' || 'BOUNCE',
-    timeout : timeout after the window loads,
-    icon : 'Specify the path of the icon',
-    //Mouse events
-    click : function (event){
-      //I promise a callback is assured for the particular event so
-      //have your code here
-    }
-  },
-  //Multiple markers are supported by
+  //markers array
   markers : [
     {
       latitude : 'Your marker latitude if empty will takes up the center latitude',
@@ -80,7 +65,6 @@ mapOptions : {
 
 }
 ```
-**NOTE** markers has more priority than marker
 
 **Supported Mouse events**
 
@@ -98,6 +82,7 @@ mapOptions : {
 Feel free to raise an issue or feature request.
 
 **DEMO**
+
 ![google-maps-addon](https://raw.githubusercontent.com/SamvelRaja/google-maps-addon/master/demo/google-maps-addon.gif)
 
 Next update would be,

--- a/addon/components/google-maps-addon.js
+++ b/addon/components/google-maps-addon.js
@@ -15,11 +15,7 @@ export default Ember.Component.extend({
         let marker_options = this.get('markerOptions');
         Helpers.initializeMouseEventCallbacks(this);
         if(marker_options){
-          if(marker_options instanceof Array ){
-            Helpers.drawAllMarkers(this);
-          } else {
-            Helpers.drawMarker(this,marker_options);
-          }
+          Helpers.drawAllMarkers(this);
         }
       }
     } else {

--- a/addon/helpers.js
+++ b/addon/helpers.js
@@ -27,13 +27,13 @@ export default{
   initializeOptions : function(context) {
     let map_options = context.get('MapOptions');
     //First preference is to 'markers' array over the 'marker' object
-    let marker_options =  map_options.markers || map_options.marker;
+    let marker_options =  map_options.markers;
     context.setProperties({
       latitude : map_options.latitude || '0',
       longitude : map_options.longitude || '0',
       zoom : map_options.zoom || 8,
     });
-    if( (marker_options instanceof Array  || marker_options instanceof Object) && !Ember.isEmpty(marker_options)){
+    if( marker_options instanceof Array  && !Ember.isEmpty(marker_options)){
       context.set('markerOptions', marker_options);
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-maps-addon",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Google maps Ember addon easy to consume",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Thinked all over the night,

The Aim of this addon to be easy consumption.

Then why the heck i added the complexity of having a additional option unnecessarily.

Removed the option immediately with a version bump
