### PR TITLE
Show a proper error message when googlemaps.js is not included

### DIFF
--- a/addon/components/google-maps-addon.js
+++ b/addon/components/google-maps-addon.js
@@ -20,8 +20,7 @@ export default Ember.Component.extend({
         Helpers.initializeInfowindow(this);
       }
     } else {
-      //Assert it if the hero(googlemaps js) is unavail
-      console.assert('Need to include the googlemaps js');
+      console.error('Need to include the googlemaps js');
     }
   }
 });


### PR DESCRIPTION
The `console.assert` always evaluated to `true` because the parameters to `console.assert` is `console.assert(boolean, message)`. Instead I chose to use `console.error` because it already was asserted with the above if-statement.

@SamvelRaja let's make this addon great :dancer: 
