### PR TITLE
Standardize camelCase for variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Google maps [ember addon](http://www.emberaddons.com/) easy to consume.
 ## Usage
 
 ```hbs
-{{google-maps-addon MapOptions=mapOptions}}
+{{google-maps-addon mapOptions=mapOptions}}
 ```
 
 We have the **JSON** **mapOptions** the powerful way to have your configurations.

--- a/addon/components/google-maps-addon.js
+++ b/addon/components/google-maps-addon.js
@@ -2,19 +2,19 @@ import Ember from 'ember';
 import Helpers from '../helpers';
 export default Ember.Component.extend({
   didInsertElement: function() {
-    var map_element;
+    var mapElement;
     //Initializing the options into the context
     Helpers.initializeOptions(this);
     //Checking for the availability of googlemaps js the hero
     if (window.google) {
-      map_element = Helpers.createMapElement(this);
+      mapElement = Helpers.createMapElement(this);
 
-      //Setting up the map_element in the context
-      if (map_element) {
-        this.set('map_element', map_element);
-        let marker_options = this.get('markerOptions');
+      //Setting up the mapElement in the context
+      if (mapElement) {
+        this.set('mapElement', mapElement);
+        let markerOptions = this.get('markerOptions');
         Helpers.initializeMouseEventCallbacks(this);
-        if (marker_options) {
+        if (markerOptions) {
           Helpers.drawAllMarkers(this);
         }
         Helpers.initializeInfowindow(this);

--- a/addon/helpers.js
+++ b/addon/helpers.js
@@ -22,19 +22,19 @@ export default{
   @method initializeOptions
   @param context
   @usage
-    To initialize the `MapOptions` as `context' properties`
+    To initialize the `mapOptions` as `context' properties`
   **/
   initializeOptions : function(context) {
-    let map_options = context.get('MapOptions');
+    let mapOptions = context.get('mapOptions') || context.get('MapOptions');
     //First preference is to 'markers' array over the 'marker' object
-    let marker_options =  map_options.markers;
+    let markerOptions =  mapOptions.markers;
     context.setProperties({
-      latitude : map_options.latitude || '0',
-      longitude : map_options.longitude || '0',
-      zoom : map_options.zoom || 8
+      latitude : mapOptions.latitude || '0',
+      longitude : mapOptions.longitude || '0',
+      zoom : mapOptions.zoom || 8
     });
-    if ( marker_options instanceof Array  && !Ember.isEmpty(marker_options)) {
-      context.set('markerOptions', marker_options);
+    if ( markerOptions instanceof Array  && !Ember.isEmpty(markerOptions)) {
+      context.set('markerOptions', markerOptions);
     }
   },
   /**
@@ -51,23 +51,23 @@ export default{
       zoom: context.get('zoom'),
       mapTypeId: google.maps.MapTypeId.ROADMAP
     };
-    var map_element = context.$('div.map-canvas')[0];
-    var map = new google.maps.Map(map_element, mapOptions);
+    var mapElement = context.$('div.map-canvas')[0];
+    var map = new google.maps.Map(mapElement, mapOptions);
     return map;
   },
   /**
   @method initializeMouseEventCallbacks
   @param context
   @usage
-    To initialize the `mouseevents` to the `map_element`
+    To initialize the `mouseevents` to the `mapElement`
   **/
   initializeMouseEventCallbacks : function(context) {
-    let map_options = context.get('MapOptions');
-    var map_element = context.get('map_element');
+    let mapOptions = context.get('mapOptions') || context.get('MapOptions');
+    var mapElement = context.get('mapElement');
     mouseEvents.forEach(function(event) {
-      if (map_options[event]) {
-        if (typeof map_options[event] === 'function') {
-          google.maps.event.addListener(map_element, event, map_options[event]);
+      if (mapOptions[event]) {
+        if (typeof mapOptions[event] === 'function') {
+          google.maps.event.addListener(mapElement, event, mapOptions[event]);
         }
       }
     });
@@ -76,31 +76,31 @@ export default{
   @method drawAllMarkers
   @param context
   @usage
-    To draw the `markers` to the `map_element`
+    To draw the `markers` to the `mapElement`
   **/
   drawAllMarkers : function(context) {
-    var marker_options = context.get('markerOptions');
+    var markerOptions = context.get('markerOptions');
     var markers = [];
     var self = this;
-    for (let i=0;i<marker_options.length;i++) {
-      markers[i] = self.drawMarker(context, marker_options[i]);
+    for (let i=0;i<markerOptions.length;i++) {
+      markers[i] = self.drawMarker(context, markerOptions[i]);
     }
     context.set('markers', markers);
   },
   /**
   @method drawMarker
-  @param context,marker_options
+  @param context,markerOptions
   @usage
-    To draw the `marker` to the `map_element`
+    To draw the `marker` to the `mapElement`
   **/
-  drawMarker : function(context, marker_options) {
-    var map_element = context.get('map_element');
-    let latitude = marker_options.latitude || context.get('latitude');
-    let longitude = marker_options.longitude || context.get('longitude');
-    let animationIndex = google.maps.Animation[marker_options.animation] || null;
-    let timeout = marker_options.timeout || 0;
-    let image_path = marker_options.icon || '//mt.googleapis.com/vt/icon/name=icons/spotlight/spotlight-poi.png&scale=1';
-    let draggable = marker_options.draggable || false;
+  drawMarker : function(context, markerOptions) {
+    var mapElement = context.get('mapElement');
+    let latitude = markerOptions.latitude || context.get('latitude');
+    let longitude = markerOptions.longitude || context.get('longitude');
+    let animationIndex = google.maps.Animation[markerOptions.animation] || null;
+    let timeout = markerOptions.timeout || 0;
+    let image_path = markerOptions.icon || '//mt.googleapis.com/vt/icon/name=icons/spotlight/spotlight-poi.png&scale=1';
+    let draggable = markerOptions.draggable || false;
     var self = this;
     var myLatlng = new google.maps.LatLng(latitude,longitude);
     var marker;
@@ -108,27 +108,27 @@ export default{
       marker = new google.maps.Marker({
         position: myLatlng,
         animation: animationIndex,
-        map: map_element,
+        map: mapElement,
         draggable: draggable,
-        title: marker_options.title || '',
+        title: markerOptions.title || '',
         icon : image_path
       });
-      marker = self.initializeMarkerMouseEventCallbacks(context, marker, marker_options);
+      marker = self.initializeMarkerMouseEventCallbacks(context, marker, markerOptions);
       return marker;
     }, timeout);
   },
 
   /**
   @method initializeMarkerMouseEventCallbacks
-  @param context,marker,marker_options
+  @param context,marker,markerOptions
   @usage
     To initialize the `markermouseevents` to the `marker_obj`
   **/
-  initializeMarkerMouseEventCallbacks : function(context, marker, marker_options) {
+  initializeMarkerMouseEventCallbacks : function(context, marker, markerOptions) {
     mouseEvents.forEach(function(event) {
-      if (marker_options[event]) {
-        if (typeof marker_options[event] === 'function') {
-          google.maps.event.addListener(marker, event, marker_options[event]);
+      if (markerOptions[event]) {
+        if (typeof markerOptions[event] === 'function') {
+          google.maps.event.addListener(marker, event, markerOptions[event]);
         }
       }
     });
@@ -141,21 +141,21 @@ export default{
     To create and the info window
   **/
   initializeInfowindow : function(context) {
-    var map_element = context.get('map_element');
-    let map_options = context.get('MapOptions');
-    let info_window_options = map_options.infowindow;
-    if (info_window_options) {
-      let longitude = info_window_options.longitude || context.get('longitude');
-      let latitude = info_window_options.latitude || context.get('latitude');
-      let info_postion = new google.maps.LatLng(latitude,longitude);
-      if (info_window_options instanceof Object && !(info_window_options instanceof Array)) {
+    var mapElement = context.get('mapElement');
+    let mapOptions = context.get('mapOptions') || context.get('MapOptions');
+    let infoWindowOptions = mapOptions.infowindow;
+    if (infoWindowOptions) {
+      let longitude = infoWindowOptions.longitude || context.get('longitude');
+      let latitude = infoWindowOptions.latitude || context.get('latitude');
+      let infoPostion = new google.maps.LatLng(latitude,longitude);
+      if (infoWindowOptions instanceof Object && !(infoWindowOptions instanceof Array)) {
         var infoWindow = new google.maps.InfoWindow({
-          content: info_window_options.content || 'empty content',
-          position : info_postion,
-          pixelOffset: info_window_options.pixelOffset || undefined,
-          maxWidth: info_window_options.maxWidth || undefined
+          content: infoWindowOptions.content || 'empty content',
+          position : infoPostion,
+          pixelOffset: infoWindowOptions.pixelOffset || undefined,
+          maxWidth: infoWindowOptions.maxWidth || undefined
         });
-        infoWindow.open(map_element);
+        infoWindow.open(mapElement);
       }
     }
   },

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -5,11 +5,11 @@ export default Ember.Controller.extend({
       latitude : '12.976299881670053',
       longitude : '80.13112306594849',
       zoom : 7,
-      click : function(rec_event) {
-        console.log('map_click' + rec_event);
+      click : function(recEvent) {
+        console.log('map_click' + recEvent);
       },
-      dblclick : function(rec_event) {
-        console.log('map_double_click' + rec_event);
+      dblclick : function(recEvent) {
+        console.log('map_double_click' + recEvent);
       },
       drag : function() {
         console.log('map_drag');
@@ -20,17 +20,17 @@ export default Ember.Controller.extend({
       dragstart : function() {
         console.log('map_dragstart');
       },
-      mousemove : function(rec_event) {
-        console.log('map_mousemove' + rec_event);
+      mousemove : function(recEvent) {
+        console.log('map_mousemove' + recEvent);
       },
-      mouseout : function(rec_event) {
-        console.log('map_mouseout' + rec_event);
+      mouseout : function(recEvent) {
+        console.log('map_mouseout' + recEvent);
       },
-      mouseover : function(rec_event) {
-        console.log('map_mouseover' + rec_event);
+      mouseover : function(recEvent) {
+        console.log('map_mouseover' + recEvent);
       },
-      rightclick : function(rec_event) {
-        console.log('map_rightclick' + rec_event);
+      rightclick : function(recEvent) {
+        console.log('map_rightclick' + recEvent);
       },
       infowindow : {
         content : '<div>Info Window</div>',
@@ -43,8 +43,8 @@ export default Ember.Controller.extend({
           latitude : '12.976299881670053',
           longitude : '80.13112306594849',
           title : 'first marker',
-          click : function(rec_event) {
-            console.log('Marker_1_click' + rec_event);
+          click : function(recEvent) {
+            console.log('Marker_1_click' + recEvent);
           },
           animation : 'DROP',
           timeout : 2000,
@@ -57,8 +57,8 @@ export default Ember.Controller.extend({
           latitude : '13.976299881670053',
           longitude : '80.13112306594849',
           title : 'first marker',
-          click : function(rec_event) {
-            console.log('Marker_2_Click' + rec_event);
+          click : function(recEvent) {
+            console.log('Marker_2_Click' + recEvent);
           },
           animation : 'BOUNCE',
           timeout : 4000,

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,2 +1,2 @@
 <h2 id="title">Google Maps addon</h2>
-{{google-maps-addon MapOptions=inputObj}}
+{{google-maps-addon mapOptions=inputObj}}


### PR DESCRIPTION
@SamvelRaja I think it would be nice if we could clean up and standardize coding conventions. What do you think? I've started by making everything regular `camelCase`. This meant:
- Changing some variables from `snake_case`
- Also, changing the `MapOptions` variable passed into `{{google-maps-addon}}` to be camelCase. To ensure backwards compatibility I kept the  option to pass in `MapOptions` as well.

What do you think? I've tested it in my application and couldn't find any regressions.
